### PR TITLE
Prepare for release v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	kmodules.xyz/custom-resources v0.25.0
 	kmodules.xyz/resource-metrics v0.25.0
 	sigs.k8s.io/controller-runtime v0.13.1
-	stash.appscode.dev/apimachinery v0.26.0
+	stash.appscode.dev/apimachinery v0.27.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1071,5 +1071,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ih
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.26.0 h1:74H87DYEMFUO6vesQARIaiXG9N6wSyakTzSoJhBRJZ0=
-stash.appscode.dev/apimachinery v0.26.0/go.mod h1:SLknx4Og4nrUflEJIQF5gjolXmetqXrpisoDlFNV2DI=
+stash.appscode.dev/apimachinery v0.27.0 h1:3Ldo0ncYnsRT4VukSrawan0jWjc+D/nss1yAyDjWj8A=
+stash.appscode.dev/apimachinery v0.27.0/go.mod h1:0bPMB3d0+3oR2hBqFeZyskBDEO5CyWnkHNV+Gp67bMA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1331,7 +1331,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.26.0
+# stash.appscode.dev/apimachinery v0.27.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis/stash
 stash.appscode.dev/apimachinery/apis/stash/install


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.03.13
Release-tracker: https://github.com/stashed/CHANGELOG/pull/63
Signed-off-by: 1gtm <1gtm@appscode.com>